### PR TITLE
Product pages: decorative banners #107

### DIFF
--- a/blocks/showcase/showcase.css
+++ b/blocks/showcase/showcase.css
@@ -46,7 +46,7 @@
 .showcase button div {
     position: absolute;
     border-width: 0;
-    max-width: 200px;
+    width: 230px;
     background-color: rgb(255 255 255);
     background-image: none;
     box-shadow: rgba(95 95 95 / 50%) 0 0 5px 0;
@@ -73,9 +73,7 @@
 /* Popover when 'hover' is activated. */
 .showcase button:hover div {
     visibility: visible;
-    display: inline;
     opacity: 1;
-    min-width: 200px;
     transition: visibility 2s, opacity 2s, display 2s linear;
 }
 
@@ -94,13 +92,16 @@
     justify-content: right;
 }
 
-.showcase > div div.showcase-hotspot-left button > div {
+.showcase > div div.showcase-hotspot-left button > div * {
     margin-right: 2px;
-    text-align: right;
+    text-align: right !important;
+    justify-content: right;
+    display: flex;
 }
 
-.showcase > div div.showcase-hotspot-right {
+.showcase > div div.showcase-hotspot-right button > div * {
     justify-content: left;
+    display: flex;
 }
 
 .showcase > div > .showcase-image-cell picture img {

--- a/blocks/vertical-selector/vertical-selector.css
+++ b/blocks/vertical-selector/vertical-selector.css
@@ -52,7 +52,6 @@
 
 .vertical-selector .fragment-viewer *.vs-active {
   min-height: 45vw;
-  max-height: 45vw;
   z-index: 50;
   background-color: #fffffff0;
   display: flex;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -333,6 +333,14 @@ function decorateBorders(main) {
       selection.querySelector('picture')?.remove();
     }
   });
+
+  const imageBorders = main.querySelectorAll('.section.images-border');
+  imageBorders.forEach((selection) => {
+    const pictures = selection.querySelectorAll('p.picture');
+    if (pictures.length === 1) {
+      pictures[0].classList.add('full-width');
+    }
+  });
 }
 
 export function decoratePictureParagraph(main) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -128,6 +128,15 @@ h2 {
   text-align: center;
 }
 
+main div.section.images-border .default-content-wrapper h2::after {
+  content: '';
+  position: absolute;
+  left: calc(50% - 5vw);
+  width: 10vw;
+  border-bottom: 2px solid var(--text-color-highlight);
+  margin-top: var(--layout-size-xxl);
+}
+
 .product .section:not(.quote) .default-content-wrapper h2::after {
   content: "";
   display: block;
@@ -559,15 +568,6 @@ main div.section.images-border > div p:not(:last-child) {
 
 main div.section.images-border > div p:last-child {
   right: 0;
-}
-
-main div.section.images-border h2::after {
-  content: '';
-  position: absolute;
-  left: calc(50% - 5vw);
-  width: 10vw;
-  border-bottom: 2px solid var(--text-color-highlight);
-  margin-top: var(--layout-size-xxl);
 }
 
 /* animations */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -540,6 +540,36 @@ main div.section.banner > div > *:nth-child(odd) {
   margin: var(--layout-size-xs) 0;
 }
 
+main div.images-border {
+  padding: 24px 0 0;
+  text-align: center;
+  font-size: larger;
+}
+
+main div.section.images-border > div p {
+  position: absolute;
+  width: 60vw;
+  margin: 0;
+  transform: translateY(-80%);
+}
+
+main div.section.images-border > div p:not(:last-child) {
+  left: 0;
+}
+
+main div.section.images-border > div p:last-child {
+  right: 0;
+}
+
+main div.section.images-border h2::after {
+  content: '';
+  position: absolute;
+  left: calc(50% - 5vw);
+  width: 10vw;
+  border-bottom: 2px solid var(--text-color-highlight);
+  margin-top: var(--layout-size-xxl);
+}
+
 /* animations */
 @media (prefers-reduced-motion: no-preference) {
   .presentation main .default-content-wrapper > h1,

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -570,6 +570,10 @@ main div.section.images-border > div p:last-child {
   right: 0;
 }
 
+main div.section.images-border > div p.full-width {
+  width: 100vw;
+}
+
 /* animations */
 @media (prefers-reduced-motion: no-preference) {
   .presentation main .default-content-wrapper > h1,

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -618,8 +618,8 @@ main div.section.images-border > div p.full-width {
       transform: translateY(100%);
       clip-path: inset(-100% -150% 100% 0);
     }
-    
-    to { 
+
+    to {
       opacity: 1;
       clip-path: inset(-100% -150% 0 0);
     }


### PR DESCRIPTION
## Issue

Fix #107

## 🔗 Test URLs:

- Before: https://main--sgws-creative--hlxsites.hlx.page/drafts/top/decorban
- After: https://decor_banners107--sgws-creative--hlxsites.hlx.page/drafts/top/decorban
- After: https://decor_banners107--sgws-creative--hlxsites.hlx.page/drafts/top/decorban-1sheet
- After: https://decor_banners107--sgws-creative--hlxsites.hlx.page/drafts/top/decorban-1aztec

- Before: https://main--sgws-creative--hlxsites.hlx.page/bloominbrands/p/6
- After: https://decor_banners107--sgws-creative--hlxsites.hlx.page/bloominbrands/p/6

One Image link: https://decor_banners107--sgws-creative--hlxsites.hlx.page/drafts/top/decorban-1image
Not a great image to use, but proves the concept - one image is `left: 0` and `width: 100vw;` (which makes it centered as well).

## 📝 Description:
Text with decorative banner, overlapping previous and next section
Trick here was really preparing the left & right images properly (from the source 4 separate images - flipping, stitching, etc.)

Also a quick fix for the vertical selector, and its default video size & showcase hotspots